### PR TITLE
Fix click outside for datepicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avantstay/avantstay-ui",
-  "version": "8.11.0",
+  "version": "8.11.1",
   "homepage": "https://github.com/avantstay/avantstay-ui",
   "bugs": "https://github.com/avantstay/avantstay-ui/issues",
   "files": [

--- a/src/DateRangePicker/DateRangePicker.tsx
+++ b/src/DateRangePicker/DateRangePicker.tsx
@@ -16,6 +16,7 @@ import {
   IconClose,
 } from './Calendar.styles'
 import { defaultClasses } from './enums'
+import { ERROR } from './colors'
 
 export type AnyDate = Date | string | number
 export type DateFactory = () => AnyDate

--- a/src/FloatingContainer/FloatingContainer.tsx
+++ b/src/FloatingContainer/FloatingContainer.tsx
@@ -71,13 +71,13 @@ class FloatingContainer extends React.PureComponent<FloatingContainerProps, Floa
 
   addWindowListeners = () => {
     setTimeout(() => {
-      window.addEventListener('click', this.onClickOut)
+      window.addEventListener('click', this.onClickOut, true)
       window.addEventListener('resize', this.onWindowResize)
     }, 10)
   }
 
   removeWindowListeners = () => {
-    window.removeEventListener('click', this.onClickOut)
+    window.removeEventListener('click', this.onClickOut, true)
     window.removeEventListener('resize', this.onWindowResize)
   }
 
@@ -86,9 +86,9 @@ class FloatingContainer extends React.PureComponent<FloatingContainerProps, Floa
   }, this.props.windowResizeDebounceDelay)
 
   onClickOut = (e: MouseEvent) => {
-    e.stopPropagation()
+    const isOutside = this.floatingContainerRef.current && !this.floatingContainerRef.current.contains(e.target)
 
-    if (this.props.show && !isDescendant(this.floatingContainerRef.current, e.target)) {
+    if (this.props.show && isOutside) {
       this.props.onClickOut && this.props.onClickOut(e)
     }
   }


### PR DESCRIPTION
Clicking outside datepicker was not working for some contexts.
This PR fixes that by changing how the check for outside is done

To test you can install the version of this PR:
yarn add "git+ssh://git@github.com:rafaelmaiach/avantstay-ui.git"