### PR TITLE
fix: Reset button padding to display arrows icon on IOS

### DIFF
--- a/src/DateRangePicker/Calendar.styles.tsx
+++ b/src/DateRangePicker/Calendar.styles.tsx
@@ -389,7 +389,7 @@ export const ClearButtonContainer = styled('div')<{ showSingleMonthPicker?: bool
       left: auto;
       right: 0;
       top: -2px;
-    } 
+    }
   `}
 
   &::before {
@@ -473,6 +473,9 @@ export const IconClose = styled(CloseIcon)`
   }
 `
 
+export const IconButton = styled.button`
+  padding: 0;
+`
 export const IconAngleRight = styled(AngleRightIcon)``
 
 export const IconAngleLeft = styled(AngleLeftIcon)``

--- a/src/DateRangePicker/Calendar.tsx
+++ b/src/DateRangePicker/Calendar.tsx
@@ -17,7 +17,7 @@ import setMonth from 'date-fns/set_month'
 import startOfDay from 'date-fns/start_of_day'
 import startOfMonth from 'date-fns/start_of_month'
 import * as React from 'react'
-import { IconAngleLeft, IconAngleRight } from './Calendar.styles'
+import { IconAngleLeft, IconAngleRight, IconButton } from './Calendar.styles'
 import { AnyDate, DateRange } from './DateRangePicker'
 import { checkEndEdge, checkRange, checkStartEdge, isOutsideMinMax } from './dateUtils'
 import DayCell from './DayCell'
@@ -161,24 +161,24 @@ class Calendar extends React.Component<any, CalendarState> {
     return (
       <div className={showSingleMonthPicker ? classes.monthAndYearWrapperSingleMonth : classes.monthAndYearWrapper}>
         {showMonthArrow ? (
-          <button type="button" className={classes.prevButton} onClick={(e: any) => this.changeMonth(-1, e)}>
+          <IconButton type="button" className={classes.prevButton} onClick={(e: any) => this.changeMonth(-1, e)}>
             <IconAngleLeft />
             <HiddenAccessibilityText>prev</HiddenAccessibilityText>
-          </button>
+          </IconButton>
         ) : null}
         <span className={classes.monthAndYearContainer}>
           <span className={classes.month}>{month}</span>
           <span className={classes.year}>{year}</span>
         </span>
         {showMonthArrow ? (
-          <button
+          <IconButton
             type="button"
             className={showSingleMonthPicker ? classes.nextButtonSingleMonth : classes.nextButton}
             onClick={(e: any) => this.changeMonth(1, e)}
           >
             <IconAngleRight />
             <HiddenAccessibilityText>next</HiddenAccessibilityText>
-          </button>
+          </IconButton>
         ) : null}
       </div>
     )


### PR DESCRIPTION

## Issue
We found an issue related to the DatePicker component on IOS devices. The report mentions that the users cannot change the month because the arrow icons that perform this action are not visible. 

### Report Ticket
[ticket](https://avantstay.slack.com/archives/CP2N169CM/p1673301670808269)

### Video of the issue: 
https://user-images.githubusercontent.com/38357905/212089373-3d2dfde3-8993-43af-8b68-11e894668bd3.MP4


### Solution
The solution was straightforward, the button that wraps the icon was not being reset to the default padding property was not zero. This way, we just reset the button padding and the icon come back to be displayed with the correct width and height.


### Test

BrowserStack with iPhone 14             |  Chrome iPhone XR
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/38357905/212090195-58556ca3-65f5-477e-b145-f79293fb961c.png)  |  ![](https://user-images.githubusercontent.com/38357905/212090385-39f7df43-0eff-4fdc-8fc9-504a69436909.png)

