### PR TITLE
feat: Allow multi selected dates on DateRangePicker

### DIFF
--- a/src/DateRangePicker/Calendar.tsx
+++ b/src/DateRangePicker/Calendar.tsx
@@ -62,6 +62,7 @@ export interface CalendarProps {
   dateTooltip?: any
   singleDateRange?: boolean
   blockedDates?: string[]
+  multiSelectedDates?: AnyDate[]
 }
 
 export interface CalendarState {
@@ -213,6 +214,7 @@ class Calendar extends React.Component<any, CalendarState> {
       dateTooltip,
       originalRange,
       blockedDates,
+      multiSelectedDates,
     } = this.props
 
     const shownDate = this.getShownDate()
@@ -257,6 +259,7 @@ class Calendar extends React.Component<any, CalendarState> {
       const { dayMoment, isPassive } = data
       const formattedDay = format(dayMoment, 'YYYY-MM-DD')
       const isSelected = !range && +parse(dayMoment) === dateUnix
+      const isMultiDateSelected = multiSelectedDates?.some(date => format(date, 'YYYY-MM-DD') === formattedDay)
       const isInRange = range && checkRange(dayMoment, range)
       const isStartEdge = range && checkStartEdge(dayMoment, range)
       const isEndEdge = (isStartEdge && range && !range.endDate) || (range && checkEndEdge(dayMoment, range))
@@ -298,7 +301,7 @@ class Calendar extends React.Component<any, CalendarState> {
           isEndEdge={!shouldNotHighlight && isEndEdge}
           hasOriginalRange={!!originalRange}
           isInOriginalRange={isInOriginalRange}
-          isSelected={!shouldNotHighlight && (isSelected || isEdge)}
+          isSelected={(!shouldNotHighlight && (isSelected || isEdge)) || isMultiDateSelected}
           isInRange={isInRange}
           isSunday={isSunday}
           isSpecialDay={isSpecialDay}

--- a/src/DateRangePicker/DateRangePicker.stories.tsx
+++ b/src/DateRangePicker/DateRangePicker.stories.tsx
@@ -7,6 +7,9 @@ import DateRangePicker from './'
 const DateRangePickerStories = storiesOf('DatePicker', module)
 const now = new Date()
 
+var threeDaysAfter = new Date(Date.now() + 3 * 86400000)
+var fiveDaysAfter = new Date(Date.now() + 5 * 86400000)
+
 DateRangePickerStories.add('Default usage', () => (
   <div>
     <p>
@@ -294,5 +297,18 @@ DateRangePickerStories.add('Default usage', () => (
       onClose={action('DateRangePicker[onClose]')}
       onInit={action('DateRangePicker[onInit]')}
       singleDateRange={true}
+    />
+  ))
+  .add('With multi selected days', () => (
+    <DateRangePicker
+      show={boolean('show', true)}
+      minDate={text('minDate', `${now.getFullYear()}-${now.getMonth() + 1}-10`)}
+      maxDate={text('maxDate', `${now.getFullYear()}-${now.getMonth() + 2}-10`)}
+      onChange={action('DateRangePicker[onChange]')}
+      onClose={action('DateRangePicker[onClose]')}
+      onInit={action('DateRangePicker[onInit]')}
+      singleDateRange={true}
+      showSingleMonthPicker
+      multiSelectedDates={[now, threeDaysAfter, fiveDaysAfter]}
     />
   ))

--- a/src/DateRangePicker/DateRangePicker.tsx
+++ b/src/DateRangePicker/DateRangePicker.tsx
@@ -67,6 +67,7 @@ export interface DateRangePickerProps {
   customHeaderComponent?: ReactNode
   shouldStartEmpty?: boolean
   showCloseButton?: boolean
+  multiSelectedDates?: AnyDate[]
 }
 
 export interface DateRangePickerState {
@@ -259,6 +260,7 @@ class DateRangePicker extends Component<DateRangePickerProps, DateRangePickerSta
       blockedDates,
       customHeaderComponent,
       showCloseButton,
+      multiSelectedDates,
     } = this.props
 
     const { range, link } = this.state
@@ -286,6 +288,7 @@ class DateRangePicker extends Component<DateRangePickerProps, DateRangePickerSta
       originalRange,
       blockedDates,
       customHeaderComponent,
+      multiSelectedDates,
     }
 
     const isBothDatesEqual =


### PR DESCRIPTION
This MR allows us to pass a new property to show multi-selected dates on the calendar; 

Example added on Storybook: 
![Screenshot 2023-04-17 at 17 31 56](https://user-images.githubusercontent.com/38357905/232603440-03cbd06a-8ee4-4424-8595-3a2cf6866f09.png)

Required UI on Tableau: 
![Screenshot 2023-04-17 at 17 32 33](https://user-images.githubusercontent.com/38357905/232603585-d8108f8c-db7b-44bc-8a0c-ee63a3887cde.png)
