### PR TITLE
Avoid verification based on range case multi-select dates

### DIFF
--- a/src/DateRangePicker/Calendar.tsx
+++ b/src/DateRangePicker/Calendar.tsx
@@ -273,20 +273,27 @@ class Calendar extends React.Component<any, CalendarState> {
       const shouldNotApplyPassive = !isInOriginalRange && !isInRange && !isStartEdge
       const isBlockedDay = blockedDates && blockedDates.includes(formattedDay)
 
-      const isAllDaysBeforeAvailable =
-        blockedDates && range && !range.endDate && isBefore(dayMoment, range.startDate)
+      const isAllDaysBeforeAvailable = () => {
+        if (multiSelectedDates) {
+          return true
+        }
+        return blockedDates && range && !range.endDate && isBefore(dayMoment, range.startDate)
           ? eachDay(dayMoment, range.startDate)
               .map(it => format(it, 'YYYY-MM-DD'))
               .every(it => !blockedDates.includes(it))
           : true
+      }
 
-      const isAllDaysAfterAvailable =
-        blockedDates && range && !range.endDate && isAfter(dayMoment, range.startDate)
+      const isAllDaysAfterAvailable = () => {
+        if (multiSelectedDates) {
+          return true
+        }
+        return blockedDates && range && !range.endDate && isAfter(dayMoment, range.startDate)
           ? eachDay(range.startDate, dayMoment)
               .map(it => format(it, 'YYYY-MM-DD'))
               .every(it => !blockedDates.includes(it))
           : true
-
+      }
       const shouldNotHighlight =
         originalRange &&
         range &&
@@ -309,7 +316,7 @@ class Calendar extends React.Component<any, CalendarState> {
           key={index}
           isPassive={
             shouldNotApplyPassive &&
-            (isPassive || isOutOfRange || isBlockedDay || !isAllDaysBeforeAvailable || !isAllDaysAfterAvailable)
+            (isPassive || isOutOfRange || isBlockedDay || !isAllDaysBeforeAvailable() || !isAllDaysAfterAvailable())
           }
           classNames={classes}
           tooltip={dateTooltip}


### PR DESCRIPTION
In v8.12.19 we add the possibility to pick more than one date using the multiple dates property, but in the case of multiple picks with blockers, we must remove the verification for all days before and after based on range. 


https://user-images.githubusercontent.com/38357905/233153279-1011fa94-93ac-4c60-b8ca-8c0f4f3cc436.mov

