### PR TITLE
feat: Display selected day based multiSelectedDates on DatePicker

### DIFF
--- a/src/DateRangePicker/Calendar.tsx
+++ b/src/DateRangePicker/Calendar.tsx
@@ -308,7 +308,7 @@ class Calendar extends React.Component<any, CalendarState> {
           isEndEdge={!shouldNotHighlight && isEndEdge}
           hasOriginalRange={!!originalRange}
           isInOriginalRange={isInOriginalRange}
-          isSelected={(!shouldNotHighlight && (isSelected || isEdge)) || isMultiDateSelected}
+          isSelected={multiSelectedDates ? isMultiDateSelected : !shouldNotHighlight && (isSelected || isEdge)}
           isInRange={isInRange}
           isSunday={isSunday}
           isSpecialDay={isSpecialDay}

--- a/src/DateRangePicker/DateRangePicker.stories.tsx
+++ b/src/DateRangePicker/DateRangePicker.stories.tsx
@@ -1,7 +1,8 @@
 import { action } from '@storybook/addon-actions'
 import { boolean, text } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
-import * as React from 'react'
+import { isSameDay } from 'date-fns'
+import React, { useState } from 'react'
 import DateRangePicker from './'
 
 const DateRangePickerStories = storiesOf('DatePicker', module)
@@ -299,16 +300,32 @@ DateRangePickerStories.add('Default usage', () => (
       singleDateRange={true}
     />
   ))
-  .add('With multi selected days', () => (
-    <DateRangePicker
-      show={boolean('show', true)}
-      minDate={text('minDate', `${now.getFullYear()}-${now.getMonth() + 1}-10`)}
-      maxDate={text('maxDate', `${now.getFullYear()}-${now.getMonth() + 2}-10`)}
-      onChange={action('DateRangePicker[onChange]')}
-      onClose={action('DateRangePicker[onClose]')}
-      onInit={action('DateRangePicker[onInit]')}
-      singleDateRange={true}
-      showSingleMonthPicker
-      multiSelectedDates={[now, threeDaysAfter, fiveDaysAfter]}
-    />
-  ))
+  .add('With multi selected days', () => {
+    const [selectedDates, setSelectedDates] = useState([now, threeDaysAfter, fiveDaysAfter])
+    return (
+      <DateRangePicker
+        show={boolean('show', true)}
+        minDate={text('minDate', `${now.getFullYear()}-${now.getMonth() + 1}-10`)}
+        maxDate={text('maxDate', `${now.getFullYear()}-${now.getMonth() + 2}-10`)}
+        onChange={date => {
+          const startDate = date?.startDate as Date
+          if (!startDate) {
+            setSelectedDates([])
+          } else {
+            const isDateSelected = selectedDates.some(currentDate => isSameDay(currentDate, startDate))
+
+            setSelectedDates(prevState =>
+              isDateSelected
+                ? [...prevState.filter(currentDate => !isSameDay(currentDate, startDate))]
+                : [...prevState, startDate]
+            )
+          }
+        }}
+        onClose={action('DateRangePicker[onClose]')}
+        onInit={action('DateRangePicker[onInit]')}
+        singleDateRange={true}
+        showSingleMonthPicker
+        multiSelectedDates={selectedDates}
+      />
+    )
+  })


### PR DESCRIPTION
Right now when we use `multiSelectedDates` that allows us to pick multi dates on the DatePicker calendar, currently the logic to check if the day is selected also uses the same logic that we use for the single-day picker. 

This MR basically removes this shared verification, because if we are using the `multiSelectedDates` we must select the days in the calendar based on the list we receive as a state. 

1. Change the logic for selected day: `isSelected={multiSelectedDates ? isMultiDateSelected : !shouldNotHighlight && (isSelected || isEdge)}`

2. Improve the storybook component