### PR TITLE
chore: ability to pass children to DateRangePicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avantstay/avantstay-ui",
-  "version": "8.12.21",
+  "version": "8.13.0",
   "homepage": "https://github.com/avantstay/avantstay-ui",
   "bugs": "https://github.com/avantstay/avantstay-ui/issues",
   "files": [

--- a/src/DateRangePicker/Calendar.styles.tsx
+++ b/src/DateRangePicker/Calendar.styles.tsx
@@ -181,19 +181,19 @@ export const CalendarContainer = styled.div<{ isSingleMonthPicker?: boolean }>`
   }
 
   ${MINW_SM_SCREEN} {
-    & .rdr-Calendar:first-child .rdr-MonthAndYear-button.next {
+    & .rdr-Calendar-0 .rdr-MonthAndYear-button.next {
       visibility: hidden;
     }
-    & .rdr-Calendar:last-child .rdr-MonthAndYear-button.next {
+    & .rdr-Calendar-1 .rdr-MonthAndYear-button.next {
       padding-right: 0;
     }
-    & .rdr-Calendar:first-child .rdr-MonthAndYear-button.prev {
+    & .rdr-Calendar-0 .rdr-MonthAndYear-button.prev {
       padding-left: 0;
     }
-    & .rdr-Calendar:last-child .rdr-MonthAndYear-button.prev {
+    & .rdr-Calendar-1 .rdr-MonthAndYear-button.prev {
       visibility: hidden;
     }
-    & .rdr-Calendar:first-child .rdr-MonthAndYear-button.next-single {
+    & .rdr-Calendar-0 .rdr-MonthAndYear-button.next-single {
       visibility: visible;
     }
   }

--- a/src/DateRangePicker/Calendar.tsx
+++ b/src/DateRangePicker/Calendar.tsx
@@ -326,12 +326,12 @@ class Calendar extends React.Component<any, CalendarState> {
   }
 
   render() {
-    const { classNames } = this.props
+    const { classNames, offset } = this.props
 
     const classes = { ...defaultClasses, ...classNames }
 
     return (
-      <div className={classes.calendar}>
+      <div className={`${classes.calendar} ${classes.calendar}-${offset}`}>
         <div className={classes.monthAndYear}>{this.renderMonthAndYear(classes)}</div>
         <div className={classes.weekDays}>{this.renderWeekdays(classes)}</div>
         <div className={classes.days}>{this.renderDays(classes)}</div>

--- a/src/DateRangePicker/DateRangePicker.tsx
+++ b/src/DateRangePicker/DateRangePicker.tsx
@@ -32,6 +32,8 @@ export type DateRange<T = AnyDate> = {
 
 export interface DateRangePickerProps {
   rootClassName?: string
+
+  children?: ReactNode
   className?: string
   clearButtonLabel?: string
   clearButtonColor?: string
@@ -232,6 +234,7 @@ class DateRangePicker extends Component<DateRangePickerProps, DateRangePickerSta
   render() {
     const {
       rootClassName,
+      children,
       className,
       format,
       linkedCalendars,
@@ -359,6 +362,7 @@ class DateRangePicker extends Component<DateRangePickerProps, DateRangePickerSta
             )}
           </div>
         </CalendarContainer>
+        {children}
       </FloatingContainer>
     )
   }


### PR DESCRIPTION
Changes:
1. Ability to pass children to achieve this:
<img width="490" alt="obraz" src="https://user-images.githubusercontent.com/4493100/236552750-83a5539e-a02d-4598-a7c2-6ea003fc6a26.png">

2. Fix for the issue of next month button showing on the first calendar:
<img width="518" alt="obraz" src="https://user-images.githubusercontent.com/4493100/236552862-5a61f698-f6a3-4e6d-9735-35fdde9618da.png">
