### PR TITLE
fix: Weekday label in case different first week day

### DIFF
--- a/src/DateRangePicker/Calendar.tsx
+++ b/src/DateRangePicker/Calendar.tsx
@@ -23,7 +23,7 @@ import { checkEndEdge, checkRange, checkStartEdge, isOutsideMinMax } from './dat
 import DayCell from './DayCell'
 import { defaultClasses, months } from './enums'
 import { HiddenAccessibilityText } from './HiddenAccessibilityText'
-import { weekdaysShort } from './weekdays'
+import { twoWeekdaysShort } from './weekdays'
 
 export interface CalendarProps {
   showMonthArrow: boolean
@@ -190,7 +190,7 @@ class Calendar extends React.Component<any, CalendarState> {
     const weekdays = []
 
     for (let i: number = firstDayOfWeek; i < 7 + firstDayOfWeek; i++) {
-      const day = weekdaysShort[i]
+      const day = twoWeekdaysShort[i]
 
       weekdays.push(
         <span className={classes.weekDay} key={i + day}>

--- a/src/DateRangePicker/DateRangePicker.stories.tsx
+++ b/src/DateRangePicker/DateRangePicker.stories.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions'
-import { boolean, text } from '@storybook/addon-knobs'
+import { boolean, text, number } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import { isSameDay } from 'date-fns'
 import React, { useState } from 'react'
@@ -327,6 +327,7 @@ DateRangePickerStories.add('Default usage', () => (
         onInit={action('DateRangePicker[onInit]')}
         singleDateRange={true}
         showSingleMonthPicker
+        firstDayOfWeek={number('firstDayOfWeek', 6)}
         multiSelectedDates={selectedDates}
       />
     )

--- a/src/DateRangePicker/weekdays.ts
+++ b/src/DateRangePicker/weekdays.ts
@@ -1,1 +1,4 @@
-export const weekdaysShort = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+const weekdaysShort = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+// This two weeks are necesary because the component allow change the first day of the week.
+export const twoWeekdaysShort = weekdaysShort.concat(weekdaysShort)


### PR DESCRIPTION
Currently, when we use the property `firstDayOfWeek` different from zero, the calendar does not render the weekday labels correctly. 

Eg.: firstDayOfWeek = 1 (Monday)
![Screenshot 2023-05-11 at 11 09 03](https://github.com/avantstay/avantstay-ui/assets/38357905/95469afc-5ed1-4fdc-858f-25ad42098ef1)


Eg.: firstDayOfWeek = 6 (Saturday)
![Screenshot 2023-05-11 at 11 09 25](https://github.com/avantstay/avantstay-ui/assets/38357905/66f6838f-10f3-490c-baf3-dacde94cbf7b)


After the fix 
![Screenshot 2023-05-11 at 11 10 38](https://github.com/avantstay/avantstay-ui/assets/38357905/35f6c810-0dab-4a71-96c3-fa85645e7a11)

![Screenshot 2023-05-11 at 11 10 52](https://github.com/avantstay/avantstay-ui/assets/38357905/ab857eb4-3cfa-4265-a655-41a56997c1e0)

